### PR TITLE
bugfix: reload the serivce when ACL files have been modified

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -34,7 +34,7 @@
   when:
     - "item['state'] == 'present'"
   with_items: "{{ mosquitto_acl_files }}"
-  notify: Restart mosquitto
+  notify: Reload mosquitto
 
 - name: Delete mosquitto_acl_files
   file:
@@ -43,7 +43,7 @@
   when:
     - "item['state'] == 'absent'"
   with_items: "{{ mosquitto_acl_files }}"
-  notify: Restart mosquitto
+  notify: Reload mosquitto
 
 - name: Create mosquitto_accounts
   template:


### PR DESCRIPTION
mosquitto re-reads the files upon reloading, and restart is not
required.